### PR TITLE
Swap native json lib for yajl

### DIFF
--- a/fluentd-monasca-output.gemspec
+++ b/fluentd-monasca-output.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name = 'fluentd-monasca-output'
-  spec.version = '1.0.0'
+  spec.version = '1.0.1'
   spec.licenses = ['Apache-2.0']
   spec.authors = ['Fujitsu Enabling Software Technology GmbH']
   spec.email = ['atanas.mirchev@est.fujitsu.com']
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'fluentd', '>= 0.10.43', '<0.14'
   spec.add_runtime_dependency 'rest-client', '~> 1.8'
+  spec.add_runtime_dependency 'yajl-ruby', '~> 1.4', '>= 1.4.1'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'webmock', '~> 1'

--- a/lib/fluent/plugin/monasca/monasca_api_client.rb
+++ b/lib/fluent/plugin/monasca/monasca_api_client.rb
@@ -9,7 +9,7 @@
 
 # encoding: utf-8
 
-require 'json'
+require 'yajl/json_gem'
 require 'rest-client'
 
 # relative requirements


### PR DESCRIPTION
This follows the advice in [1] to work around parse errors such as:

Bulk sending messages to monasca-log-api threw exception
exceptionew=#<Encoding::UndefinedConversionError: "\xC2" from ASCII-8BIT to UTF-8>

[1] https://docs.fluentd.org/quickstart/faq#i-got-encoding-error-inside-plugin-how-to-fix-it