### PR TITLE
Upgrade rest-client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ There is currently no support for looking up a logging endpoint from the Keyston
  - Support posting logs to the unified Monasca API
  - Remove support for posting logs to Monasca Log API
 ### 1.0.1
- - Swith to yajl JSON parser to fix issue parsing some logs
+ - Switch to yajl JSON parser to fix issue parsing some logs
+### 1.0.2
+ - Upgrade rest-client library to work with openssl 2.x

--- a/fluentd-monasca-output.gemspec
+++ b/fluentd-monasca-output.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |spec|
   spec.name = 'fluentd-monasca-output'
-  spec.version = '1.0.1'
+  spec.version = '1.0.2'
   spec.licenses = ['Apache-2.0']
   spec.authors = ['Fujitsu Enabling Software Technology GmbH']
   spec.email = ['atanas.mirchev@est.fujitsu.com']
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'fluentd', '>= 0.10.43', '<0.14'
-  spec.add_runtime_dependency 'rest-client', '~> 1.8'
+  spec.add_runtime_dependency 'rest-client', '~> 2.0'
   spec.add_runtime_dependency 'yajl-ruby', '~> 1.4', '>= 1.4.1'
 
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
The removal of the ciphers param from the defaults in the
openssl 2.x library is not compatible with the current version
of the rest-client library and can cause a failure such as:

KeyError error="key not found: :ciphers"

This change upgrades the rest-client library to a more recent
release which is compatible with the 2.x release of openssl.